### PR TITLE
Allow to configure an http_adapter for Faraday.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ end
 
 ```
 
+The `http_adapter` option can be used to set the underlying HTTP adapter for Faraday:
+
+```
+config.http_adapter = :typhoeus
+```
+
+Use an array to pass further options to the HTTP adapter itself:
+
+```
+config.http_adapter = [:typhoeus, timeout_ms: 100]
+```
+
 ## Usage
 
 After configuring a `client`, the following calls are available to you:

--- a/lib/telleroo/configuration.rb
+++ b/lib/telleroo/configuration.rb
@@ -1,4 +1,5 @@
 require 'active_support/configurable'
+require 'faraday'
 
 module Telleroo
   # Configuration.
@@ -7,16 +8,21 @@ module Telleroo
   # Telleroo.configure do |config|
   #   config.authorization_token = 'deadbeef'
   #   config.endpoint = 'https://sandbox.telleroo.com'
+  #   config.http_adapter = :typhoeus
   # end
 
   class Configuration
     include ActiveSupport::Configurable
-    VALID_CONFIG_KEYS = [:authorization_token, :endpoint].freeze
+    VALID_CONFIG_KEYS = [:authorization_token, :endpoint, :http_adapter].freeze
 
     config_accessor :authorization_token
 
     config_accessor :endpoint do
       'https://sandbox.telleroo.com'
+    end
+
+    config_accessor :http_adapter do
+      Faraday.default_adapter
     end
 
     # Return the configuration values set in this module

--- a/lib/telleroo/connection.rb
+++ b/lib/telleroo/connection.rb
@@ -13,7 +13,7 @@ module Telleroo
         faraday.use Telleroo::Response::RaiseServerError
         faraday.headers['Authorization'] = @authorization_token
         faraday.headers['Content-Type'] = 'application/json'
-        faraday.adapter Faraday.default_adapter
+        faraday.adapter *@http_adapter
       end
     end
   end

--- a/spec/lib/telleroo/configuration_spec.rb
+++ b/spec/lib/telleroo/configuration_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Telleroo::Configuration do
     Telleroo.configure do |config|
       config.authorization_token = 'foo'
       config.endpoint = 'https://example.com/v1'
+      config.http_adapter = :typhoeus
     end
   end
 
@@ -27,6 +28,17 @@ RSpec.describe Telleroo::Configuration do
     it 'uses sandbox as default endpoint' do
       endpoint = Telleroo::Configuration.new.endpoint
       expect(endpoint).to eq('https://sandbox.telleroo.com')
+    end
+  end
+
+  describe '.http_adapter' do
+    it 'should return default http adapter' do
+      expect(Telleroo.config.http_adapter).to eq(:typhoeus)
+    end
+
+    it 'uses Faraday.default_adapter as default http adapter' do
+      endpoint = Telleroo::Configuration.new.http_adapter
+      expect(endpoint).to eq(Faraday.default_adapter)
     end
   end
 


### PR DESCRIPTION
@playpasshq thanks for working on this Telleroo API wrapper! 

Please consider the following PR for inclusion: we need to use a custom http adapter for faraday and to be able to setup different configuration options (e.g. network timeouts among others).

---

This changeset extends the configuration of the library to add support
for an `http_adapter` option, which is passed down to Faraday and allows
to set a custom adapter to execute API calls.
It can be useful in circumstances where you want to switch using a
different, more performant or more customisable http client.